### PR TITLE
:bug: 앱 첫 진입후 미니배너에서 노란색 테두리 생기는 버그 수정

### DIFF
--- a/src/feature/screen/linear/banner/MiniBanner.tsx
+++ b/src/feature/screen/linear/banner/MiniBanner.tsx
@@ -72,9 +72,7 @@ const Content = styled.div`
     flex-direction: column;
 `;
 
-const Container = styled(Content).attrs({
-    tabIndex: 0,
-})`
+const Container = styled(Content)`
     position: absolute;
     top: 30%;
     left: 0;
@@ -83,10 +81,6 @@ const Container = styled(Content).attrs({
     border-top-right-radius: 16rem;
     border-bottom-right-radius: 16rem;
     background-color: rgba(17, 24, 39, 0.5);
-
-    :focus {
-        outline: none;
-    }
 `;
 
 const ChannelNo = styled.span`


### PR DESCRIPTION
## Summary
앱에 처음 진입하고 채널 재핑으로 미니 배너를 볼 시 노란색 테두리가 생깁니다.
처음 미니배너를 보고 이후의 미니배너에서는 나오지 않습니다.

## Describe your changes
해당 미니배너 컴포넌트에 
- 포커스가 안 되게
- 포커스가 되어도 outline이 안 잡히게
수정하였습니다.

## Issue number
[p-530](https://app.asana.com/0/0/1209040145126776/f)