### PR TITLE
:bug: 미니배너 있을시 ok하면 채널배너 안 나오는 버그 수정

### DIFF
--- a/src/feature/screen/linear/banner/MiniBanner.tsx
+++ b/src/feature/screen/linear/banner/MiniBanner.tsx
@@ -72,7 +72,9 @@ const Content = styled.div`
     flex-direction: column;
 `;
 
-const Container = styled(Content)`
+const Container = styled(Content).attrs({
+    tabIndex: 0,
+})`
     position: absolute;
     top: 30%;
     left: 0;
@@ -81,8 +83,11 @@ const Container = styled(Content)`
     border-top-right-radius: 16rem;
     border-bottom-right-radius: 16rem;
     background-color: rgba(17, 24, 39, 0.5);
-`;
 
+    &:focus {
+        outline: none;
+    }
+`;
 const ChannelNo = styled.span`
     font: ${({ theme }) =>
         `${theme.fonts.weight.bold} 56rem/66rem ${theme.fonts.family.pretendard}`};


### PR DESCRIPTION
## Summary
기존 #18 에 있던 수정사항을 적용시 생기는 버그입니다.
디바이스에서만 일어납니다.

## Describe your changes
해당 #18 의 수정사항을 원복하고 styled-components의 focus 로직이 &:focus가 되도록 수정하였습니다.

## Issue number
[p-536](https://app.asana.com/0/0/1209041347542878/f)
#18 
