### PR TITLE
🐛 디바이스에서 채널 재핑 2번 이상 했을시 채널배너가 안 켜지는 버그 수정

### DIFF
--- a/src/feature/screen/linear/banner/ChannelBannerInfo.tsx
+++ b/src/feature/screen/linear/banner/ChannelBannerInfo.tsx
@@ -42,7 +42,7 @@ export function ChannelBannerInfo() {
     ) : (
         <Container>
             <ChannelInfo>
-                <span>Ch {info.channelInfo?.no}</span>
+                <span>CH {info.channelInfo?.no}</span>
                 <span>{info.channelInfo?.title}</span>
             </ChannelInfo>
             <EpisodeInfo>

--- a/src/feature/screen/linear/banner/MiniBanner.tsx
+++ b/src/feature/screen/linear/banner/MiniBanner.tsx
@@ -34,7 +34,7 @@ export function MiniBanner() {
                 <Loading />
             ) : (
                 <Content>
-                    <ChannelNo>Ch {info.channelInfo?.no}</ChannelNo>
+                    <ChannelNo>CH {info.channelInfo?.no}</ChannelNo>
                     <ChannelName>{info.channelInfo?.title}</ChannelName>
                     <EpisodeTitle
                         delay={2}
@@ -111,6 +111,7 @@ const Thumbnail = styled(LoadThumbnail)`
     margin-right: 40rem;
     border-radius: 16rem;
     object-fit: cover;
+    pointer-events: none;
 `;
 
 const EpisodeTitle = styled(Marquee)`


### PR DESCRIPTION
## Summary
- 채널 배너와 미니 배너에서의 'Ch' 텍스트를 'CH' 로 변경했습니다.
- 디바이스에서의 Enter 이벤트가 채널 재핑을 2번 하면 미니배너의 썸네일에서 작동하여 채널 배너가 안켜지는 버그를 수정했습니다.

## Describe your changes
미니배너의 썸네일 컴포넌트에 클릭이벤트가 작동하지 않게 하기 위해 pointer-events: none; 을 추가했습니다.
왜 2번 이상 재핑을 했을시 해당현상이 발생하는지는 파악하지 못했고 알게 되면 다시 정리할 수 있도록 하겠습니다.

## Issue number
[p-536](https://app.asana.com/0/1208396442682864/1209041347542878/f)

## Link
[미니배너 CH figma](https://www.figma.com/design/S7Y3937pMn5wtS6a1LxLuR/dlive_platform_tvapp_ui_v1.0?node-id=14659-38616&t=7YdrPuTv45UYkPyO-0)