### PR TITLE
:bug: 가이드에서 에피소드와 인디케이터가 맞지 않는 버그 수정

### DIFF
--- a/src/atom/screen/linear.ts
+++ b/src/atom/screen/linear.ts
@@ -114,7 +114,7 @@ export interface TimeBarOffsetValues {
     max: number;
 }
 
-const MAX_TIME_BAR_OFFSET = TIME_SLOT_MAX_MILLIS / TIME_SLOT_MILLIS - 2;
+const MAX_TIME_BAR_OFFSET = TIME_SLOT_MAX_MILLIS / TIME_SLOT_MILLIS - 2.456;
 export const timeBarOffsetValuesSelector = atom<TimeBarOffsetValues>((get) => {
     return {
         min: 0,
@@ -130,9 +130,9 @@ export const timeBarOffsetReducer = (
     },
 ) => {
     if (action.type === 'INCREMENT') {
-        return coerceAtMost(prev + 2, MAX_TIME_BAR_OFFSET);
+        return coerceAtMost(prev + 2.456, MAX_TIME_BAR_OFFSET);
     } else if (action.type === 'DECREMENT') {
-        return coerceAtLeast(prev - 2, 0);
+        return coerceAtLeast(prev - 2.456, 0);
     } else if (action.type === 'RESET') {
         return 0;
     } else {
@@ -176,7 +176,7 @@ export const visibleTimesInTimeBar = atom((get) => {
     const timeBarOffset = get(timeBarOffsetState);
 
     const start = openingMillis + timeBarOffset * TIME_SLOT_MILLIS;
-    const end = start + TIME_SLOT_MILLIS * 2;
+    const end = start + TIME_SLOT_MILLIS * 2.456;
     return [start, end];
 });
 


### PR DESCRIPTION
## Summary
- paro 대비 가이드의 width가 늘어난 비율만큼 관련 수치들을 수정하였습니다.
  - 이전 상황에서는 (타임바가 1시간 단위로 깔끔하게 보인다 해도) episode cell이 실제 시간과 다르게 보이기 때문입니다.
- 이렇게 할 경우 paro와 다르게 timebar가 움직이는 것처럼 보입니다.
  - 그 이유는 이번에 가이드의 카테고리바가 사라지며 늘어난 width로 인해 기존의 1시간 단위로 보이던 가이드가 약 1시간 15분 정도 보이게 되고 따라서 paro와는 달리 15:00, 15:30, 16:00 이후 16:15 16:45 17:15 단위로 보이게 되기 때문입니다.
-  이 이슈는 추후 수정요청이 있을시 다시 수정 진행하기로 하였습니다.
## Issue number
[p-541](https://app.asana.com/0/0/1209050142406501/f)
