### PR TITLE
🐛 초기 로딩시 Exit 플로우 추가

### DIFF
--- a/src/component/LoadingSpinner.tsx
+++ b/src/component/LoadingSpinner.tsx
@@ -1,12 +1,31 @@
 import styled, { keyframes } from 'styled-components';
 import Spinner from '@/asset/icSpinner.png';
 import { IExtendableStyledComponent } from '@/type/common';
+import { useEffect } from 'react';
+import { ESCAPE } from '@/util/eventKey.ts';
+import { closeApp } from '@/util/closeApp.ts';
+import { userAgent } from '@/util/userAgent';
 
 type Props = IExtendableStyledComponent & {
     message?: string;
 };
 
 export function LoadingSpinner({ className }: Props) {
+    useEffect(() => {
+        function handleKeyDown(event: KeyboardEvent) {
+            event.preventDefault();
+
+            if (event.keyCode === ESCAPE) {
+                closeApp(userAgent.type);
+            }
+        }
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, []);
+
     return (
         <Container className={className} aria-live={'assertive'}>
             <Element src={Spinner} alt={'loading'} />


### PR DESCRIPTION
## Summary
- 기존 diva는 초기 로딩시 exit이 가능하고
- 우리 앱에서도 초기 로딩에 계속 머무르는 에러케이스가 있을 수 있으므로 해당 플로우를 추가했습니다.

## Issue number
[p-542](https://app.asana.com/0/0/1209050142406520/f)
