### PR TITLE
🌐 GEO block 페이지 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="os" content="OS_NAME">
+    <meta property="locale" content="LOCALE_NAME">
     <title>DIVA</title>
     <style>body {
         background-color: #515152;

--- a/src/app/withLoading.tsx
+++ b/src/app/withLoading.tsx
@@ -5,10 +5,19 @@ import styled from 'styled-components';
 import { useGetSchedule } from '@/api/scheduleQuery.ts';
 import { useDetectOnline } from '@/hook/useDetectOnline.ts';
 import { NetworkErrorPage } from '@/app/NetworkErrorPage.tsx';
+import { getLocale } from '@/util/getLocale.ts';
 
 export const withLoading = (WrappedComponent: React.ComponentType) => {
     return function Component() {
+        const locale = getLocale();
         const { isOnline, setOnline } = useDetectOnline();
+
+        if (locale !== 'kr') {
+            return <ErrorPage />;
+        }
+
+        // 데이터 받기 이전에 국가제한을 해야 하므로 조건부로 hook을 호출되면 안된다는 규칙 무시
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         const { isLoading, isError } = useGetSchedule();
 
         return isOnline ? (

--- a/src/component/ErrorPage.tsx
+++ b/src/component/ErrorPage.tsx
@@ -4,8 +4,10 @@ import { ENTER, onDefaultUIEvent } from '@/util/eventKey';
 import { t } from 'i18next';
 import { closeApp } from '@/util/closeApp.ts';
 import { userAgent } from '@/util/userAgent';
+import { getLocale } from '@/util/getLocale.ts';
 
 export function ErrorPage() {
+    const locale = getLocale();
     const handleExit = () => closeApp(userAgent.type);
 
     const handleKeyDown = (event: React.KeyboardEvent) => {
@@ -26,10 +28,21 @@ export function ErrorPage() {
     return (
         <Container>
             <Column>
-                <Title id={'title'}>{t('app_query_error_title')}</Title>
-                <Description id={'desc'}>
-                    {t('app_query_error_description')}
-                </Description>
+                {locale !== 'kr' ? (
+                    <>
+                        <Title id={'title'}>{t('geo_block_error_title')}</Title>
+                        <Description id={'desc'}>
+                            {t('geo_block_error_description')}
+                        </Description>
+                    </>
+                ) : (
+                    <>
+                        <Title id={'title'}>{t('app_query_error_title')}</Title>
+                        <Description id={'desc'}>
+                            {t('app_query_error_description')}
+                        </Description>
+                    </>
+                )}
                 <Row>
                     <Button
                         role={'button'}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -22,6 +22,8 @@
     "network_error_exit": "Exit",
     "app_query_error_title": "Sorry, we’re failed to load the Information",
     "app_query_error_description": "Please exit the app and run it again",
+    "geo_block_error_title": "서비스 지역이 아닙니다",
+    "geo_block_error_description" : "이 서비스는 한국 거주자에게만 제공됩니다.\nThis service is only for people in South Korea.",
     "time": "{val, datetime}",
     "press_back_again_to_exit": "Press BACK button once more to exit"
 }

--- a/src/lang/ko.json
+++ b/src/lang/ko.json
@@ -22,6 +22,8 @@
     "network_error_exit": "종료하기",
     "app_query_error_title": "정보를 불러오지 못했습니다",
     "app_query_error_description" : "앱을 종료하고 다시 실행해주세요.",
+    "geo_block_error_title": "서비스 지역이 아닙니다",
+    "geo_block_error_description" : "이 서비스는 한국 거주자에게만 제공됩니다.\nThis service is only for people in South Korea.",
     "time": "{val, datetime}",
     "press_back_again_to_exit": "뒤로가기를 한 번 더 누르면 앱이 종료됩니다"
 }

--- a/src/type/userAgent.ts
+++ b/src/type/userAgent.ts
@@ -4,6 +4,12 @@ export const UserAgentOS = {
 } as const;
 export type UserAgentOS = (typeof UserAgentOS)[keyof typeof UserAgentOS];
 
+export const UserAgentLocale = {
+    DEFAULT: 'KR',
+} as const;
+export type UserAgentLocale =
+    (typeof UserAgentLocale)[keyof typeof UserAgentLocale];
+
 export interface ITargetOS {
     type: UserAgentOS;
 }

--- a/src/util/getLocale.ts
+++ b/src/util/getLocale.ts
@@ -1,0 +1,12 @@
+import { UserAgentLocale } from '@/type/userAgent.ts';
+
+export function getLocale() {
+    const metaContentName = document
+        .querySelector('meta[property="locale"]')
+        ?.getAttribute('content');
+    if (!metaContentName) return UserAgentLocale.DEFAULT;
+
+    const matchedLocale = metaContentName.toLowerCase();
+
+    return matchedLocale ?? UserAgentLocale.DEFAULT;
+}


### PR DESCRIPTION
## Summary
웹뷰로부터 meta태그로 국가정보를 받아 
kr이 아닐경우 서버에 채널 데이터 api 요청을 하기전에 geo block 에러페이지로 이동시킵니다.

## Describe your changes
```tsx
export function getLocale() {
    const metaContentName = document
        .querySelector('meta[property="locale"]')
        ?.getAttribute('content');
    if (!metaContentName) return UserAgentLocale.DEFAULT;

    const matchedLocale = metaContentName.toLowerCase();

    return matchedLocale ?? UserAgentLocale.DEFAULT;
}
```

## Issue number
[p-546](https://app.asana.com/0/1208396442682864/1209051254270361/f)

## Link
[figma](https://www.figma.com/design/S7Y3937pMn5wtS6a1LxLuR/dlive_platform_tvapp_ui_v1.0?node-id=14726-11646&t=v5QAGK7LsW3PVy2l-0)