### PR TITLE
🔥 watch history 로직 제거

### DIFF
--- a/src/api/scheduleQuery.ts
+++ b/src/api/scheduleQuery.ts
@@ -5,7 +5,7 @@ import { appService } from '@/api/service/app';
 import { ScheduleResponse } from '@/api/model/schedule';
 import { LinearResponse } from '@/api/model/app';
 import { DEFAULT_LOCALE } from '@/app/environment';
-import { lastUpdatedTimeState, writeWatchHistory } from '@/atom/app';
+import { lastUpdatedTimeState } from '@/atom/app';
 import {
     channelNowState,
     channelsState,
@@ -73,15 +73,6 @@ export const useGetSchedule = () => {
                 onAirScheduleEndTimeState,
                 airingEpisode ? toMillis(airingEpisode.endAt) : -1,
             );
-
-            if (airingEpisode) {
-                set(writeWatchHistory, {
-                    type: 'linear',
-                    content: {
-                        contentId: channel.contentId,
-                    },
-                });
-            }
         }, []),
     );
 

--- a/src/atom/app.ts
+++ b/src/atom/app.ts
@@ -1,18 +1,11 @@
 import { atomWithLocalStorage } from '../util/localStorage.atom';
-import { atom, PrimitiveAtom, useAtom } from 'jotai';
+import { PrimitiveAtom, useAtom } from 'jotai';
 import { ContentType } from '../type/common';
-import { ChannelEpisode } from '../type/linear';
 import { atomWithStorage, createJSONStorage } from 'jotai/utils';
 import { useCallback } from 'react';
 
 export type TMyListContents = {
     [val in ContentType]: string[];
-};
-
-export type LinearWatchHistory = Pick<ChannelEpisode, 'contentId'>;
-
-export type TWatchedContent = {
-    linear: LinearWatchHistory[];
 };
 
 export const uuidState = atomWithLocalStorage('uuid', '');
@@ -26,66 +19,6 @@ const initialMyListContent = Object.values(ContentType).reduce((acc, val) => {
 export const mylistState = atomWithStorage<TMyListContents>(
     'favorite',
     initialMyListContent,
-);
-
-const initialWatchHistoryContent: TWatchedContent = {
-    linear: [],
-};
-
-export const watchHistoryState = atomWithStorage<TWatchedContent>(
-    'watch',
-    initialWatchHistoryContent,
-);
-
-const MAX_WATCH_HISTORY_COUNT = 30;
-
-export const writeWatchHistory = atom(
-    null,
-    (
-        get,
-        set,
-        item: {
-            content: LinearWatchHistory;
-            type: ContentType;
-        },
-    ) => {
-        const watchedContents = get(watchHistoryState);
-        const { content, type } = item;
-
-        const history = watchedContents[type];
-        if (!history) return;
-
-        const existingIndex = history.findIndex(
-            (item) => item.contentId === content.contentId,
-        );
-
-        if (existingIndex !== -1) {
-            const updatedHistory = [...history];
-            updatedHistory.splice(existingIndex, 1);
-
-            if (updatedHistory.length >= MAX_WATCH_HISTORY_COUNT) {
-                updatedHistory.shift();
-            }
-            updatedHistory.push(content);
-
-            set(watchHistoryState, {
-                ...watchedContents,
-                [type]: updatedHistory,
-            });
-        } else {
-            const updatedHistory = [...history];
-
-            if (updatedHistory.length >= MAX_WATCH_HISTORY_COUNT) {
-                updatedHistory.shift();
-            }
-            updatedHistory.push(content);
-
-            set(watchHistoryState, {
-                ...watchedContents,
-                [type]: updatedHistory,
-            });
-        }
-    },
 );
 
 export const lastUpdatedTimeState = atomWithStorage<number>(

--- a/src/atom/screen/index.ts
+++ b/src/atom/screen/index.ts
@@ -3,7 +3,7 @@ import { atomFamily } from 'jotai/utils';
 import { Channel, ChannelEpisode } from '@/type/linear';
 import { ContentType, Nullable, Optional } from '@/type/common';
 import { MyListCategory } from '@/type/category';
-import { mylistState, watchHistoryState } from '@/atom/app';
+import { mylistState } from '@/atom/app';
 import {
     scheduleCategories,
     selectedScheduleCategoryIdxState,
@@ -174,14 +174,6 @@ export const scheduleEnabledState = atom(false);
 
 export const readInitialChannel = atom((get) => {
     const channels = get(channelsState);
-    const watchHistory = get(watchHistoryState);
 
-    const recentlyWatchedChannelId =
-        watchHistory[ContentType.LINEAR]?.slice(-1)?.[0]?.contentId;
-
-    const initialChannel = channels.find(
-        (channel) => channel.contentId === recentlyWatchedChannelId,
-    );
-
-    return initialChannel || channels?.[0];
+    return channels?.[0];
 });

--- a/src/util/getLocale.ts
+++ b/src/util/getLocale.ts
@@ -8,5 +8,6 @@ export function getLocale() {
 
     const matchedLocale = metaContentName.toLowerCase();
 
-    return matchedLocale ?? UserAgentLocale.DEFAULT;
+    return 'kr';
+    // return matchedLocale ?? UserAgentLocale.DEFAULT;
 }


### PR DESCRIPTION
## Summary
디바와 동일하게 유저가 앱을 진입할때마다 0번째 채널을 보여주기로 했기 때문에 
watch history로직이 필요없다고 판단하여 다 제거하기로 하였습니다.
추후 만약 유저가 들어간 채널들을 기억해야 하는 요구사항이 있다면 추가합니다.

국가제한로직에 우선 kr만 반환하도록 수정했습니다. 
이는 브라우저 개발환경에서는 웹뷰를 거치지 않기때문에 제대로된 국가를 받아오지 않아 앱 진입이 안되기 때문이며
추후 다시 수정할 예정입니다.

## Issue number
[p-548](https://app.asana.com/0/1208396442682864/1209051254270365/f)
#28 